### PR TITLE
Fixed bug where local timezone was used instead of UTC

### DIFF
--- a/lib/broutes/formats/fit_file.rb
+++ b/lib/broutes/formats/fit_file.rb
@@ -34,7 +34,7 @@ module Broutes::Formats
     def record_time(record)
       utc_seconds = record.content.timestamp
       utc_seconds += record.header.time_offset if record.header.compressed_timestamp? 
-      Time.new(1989, 12, 31) + utc_seconds
+      Time.new(1989, 12, 31, 0, 0, 0, "+00:00") + utc_seconds #seconds since UTC 00:00 Dec 31 1989
     end
 
   end


### PR DESCRIPTION
Hi, I noticed that the tests failed on my machine and investigated why. It was due to that Time.new() uses the local timezone if not given:
```
irb(main):004:0> Time.new(1989, 12, 31, 0, 0, 0, "+00:00").to_i
=> 631065600
irb(main):005:0> Time.new(1989, 12, 31).to_i
=> 631062000
```
Thus changed so the correct time reference is used when adding the seconds from the FIT message.